### PR TITLE
Update advancedsearch.user.js

### DIFF
--- a/advancedsearch.user.js
+++ b/advancedsearch.user.js
@@ -3853,7 +3853,7 @@ function hoverHighlightDetailWizParams(paramtext, $hoverObject){
 
 function addPriceBreakHelper(){
     _log('addPriceBreakHelper() Start',DLOG);
-    var ptable = $('#product-dollars');
+    var ptable = $('.product-dollars');
     // var eurocheckRE = /(?.*,\d\d)/; 
     // check if part is not orderable
     if(ptable.filter(':contains(call)').size() == 0){


### PR DESCRIPTION
Found that the details page price break calculator wasn't finding the values because the selector used switched from ID to class. Small operators tweak gets it working again. Not sure if there is a better way to do this or not.